### PR TITLE
DEVOPS-106 Migration tests of the (RCIAM) role NGINX in Ansible 2.9.

### DIFF
--- a/roles/nginx/tasks/install-Debian.yml
+++ b/roles/nginx/tasks/install-Debian.yml
@@ -5,7 +5,9 @@
   become: yes
 
 - name: Ensure nginx server is installed (Debian)
-  apt: name={{ item }} state=present install_recommends=no
-  with_items:
-    - nginx
+  apt:
+    name:
+      - nginx
+    state: present
+    install_recommends: no
   become: yes


### PR DESCRIPTION
Because of the following `DEPRECATION WARNING`:

```
TASK [nginx : Ensure nginx server is installed (Debian)] *****************************************************************************************
[DEPRECATION WARNING]: Invoking "apt" only once while using a loop via squash_actions is deprecated. Instead of using a loop to supply multiple 
items and specifying `name: "{{ item }}"`, please use `name: ['nginx']` and remove the loop. This feature will be removed in version 2.11. 
Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
```