### PR TITLE
Bug fix shibboleth2.xml.j2

### DIFF
--- a/roles/shibboleth-sp/templates/shibboleth2.xml.j2
+++ b/roles/shibboleth-sp/templates/shibboleth2.xml.j2
@@ -260,7 +260,7 @@
                     entityID="{{ override.sso.entity_id }}"
 {% endif %}
 {% if override.sso.force_authn is defined %}
-                    forchAuthn="{{ override.sso.force_authn }}"
+                    forceAuthn="{{ override.sso.force_authn }}"
 {% endif %}
                 >
                   {{ override.sso.protocols }}


### PR DESCRIPTION
Fix typo error. forchAuthn config in SSO must be renamed to forceAuthn