### PR TITLE
Support tomcat static cluster configuration

### DIFF
--- a/roles/tomcat/defaults/main.yml
+++ b/roles/tomcat/defaults/main.yml
@@ -30,7 +30,7 @@ tomcat_connectors:
     #scheme: "https"
     uri_encoding: "UTF-8"
 
-cluster_mode: False
+tomcat_cluster_mode: no
 
 tomcat_cluster:
   - channel_send_options: "8"

--- a/roles/tomcat/defaults/main.yml
+++ b/roles/tomcat/defaults/main.yml
@@ -29,3 +29,22 @@ tomcat_connectors:
     redirect_port: "8443"
     #scheme: "https"
     uri_encoding: "UTF-8"
+
+cluster_mode: False
+
+tomcat_cluster:
+  - channel_send_options: "8"
+    channel_start_options: "3"
+    expire_sessions_on_shutdown: "false"
+    notify_listeners_on_replication: "true"
+    receiver:
+      - address: ""
+        auto_bind: "100"
+        max_threads: "6"
+        port: "4100"
+        selector_timeout: "5000"
+    interceptor_static_only: "true"
+    members:
+      - host: ""
+        port: "4100"
+        unique_id: ""

--- a/roles/tomcat/templates/server.xml.j2
+++ b/roles/tomcat/templates/server.xml.j2
@@ -115,9 +115,80 @@
       <!--For clustering, please take a look at documentation at:
           /docs/cluster-howto.html  (simple how to)
           /docs/config/cluster.html (reference documentation) -->
+{% if cluster_mode %}
+{% for cluster in tomcat_cluster %}
+      <Cluster className="org.apache.catalina.ha.tcp.SimpleTcpCluster"
+{% if cluster.channel_send_options is defined %}
+               channelSendOptions="{{ cluster.channel_send_options }}"
+{% endif %}
+{% if cluster.channel_start_options is defined %}
+               channelStartOptions="{{ cluster.channel_start_options }}"
+{% endif %}
+      >
+          <Manager className="org.apache.catalina.ha.session.DeltaManager"
+{% if cluster.expire_sessions_on_shutdown is defined %}
+                   expireSessionsOnShutdown="{{ cluster.expire_sessions_on_shutdown }}"
+{% endif %}
+{% if cluster.notify_listeners_on_replication is defined %}
+                   notifyListenersOnReplication="{{ cluster.notify_listeners_on_replication }}"
+{% endif %}
+          />
+          <Channel className="org.apache.catalina.tribes.group.GroupChannel">
+            <Sender className="org.apache.catalina.tribes.transport.ReplicationTransmitter">
+              <Transport className="org.apache.catalina.tribes.transport.nio.PooledParallelSender" />
+            </Sender>
+{% for receiver in cluster.receiver %}
+            <Receiver className="org.apache.catalina.tribes.transport.nio.NioReceiver"
+{% if receiver.address is defined %}
+                      address="{{ receiver.address }}"
+{% endif %}
+{% if receiver.auto_bind is defined %}
+                      autoBind="{{ receiver.auto_bind }}"
+{% endif %}
+{% if receiver.max_threads is defined %}
+                      maxThreads="{{ receiver.max_threads }}"
+{% endif %}
+{% if receiver.port is defined %}
+                      port="{{ receiver.port }}"
+{% endif %}
+{% if receiver.selector_timeout is defined %}
+                      selectorTimeout="{{ receiver.selector_timeout }}"
+{% endif %}
+{% endfor %}
+            />
+            <!-- <Interceptor className="com.dm.tomcat.interceptor.DisableMulticastInterceptor" /> -->
+            <Interceptor className="org.apache.catalina.tribes.group.interceptors.TcpPingInterceptor"
+{% if cluster.interceptor_static_only is defined %}
+                         staticOnly="{{ cluster.interceptor_static_only }}"
+{% endif %}
+            />
+            <Interceptor className="org.apache.catalina.tribes.group.interceptors.TcpFailureDetector" />
+            <Interceptor className="org.apache.catalina.tribes.group.interceptors.StaticMembershipInterceptor">
+{% for member in cluster.members %}
+              <Member className="org.apache.catalina.tribes.membership.StaticMember"
+{% if member.host is defined %}
+                      host="{{ member.host }}"
+{% endif %}
+{% if member.port is defined %}
+                      port="{{ member.port }}"
+{% endif %}
+{% if member.unique_id is defined %}
+                      uniqueId="{{ member.unique_id }}"
+{% endif %}
+{% endfor %}
+              />
+            </Interceptor>
+            <Interceptor className="org.apache.catalina.tribes.group.interceptors.MessageDispatch15Interceptor" />
+          </Channel>
+          <Valve className="org.apache.catalina.ha.tcp.ReplicationValve" filter=".*\.gif;.*\.js;.*\.jpg;.*\.png;.*\.htm;.*\.html;.*\.css;.*\.txt;" />
+          <ClusterListener className="org.apache.catalina.ha.session.ClusterSessionListener" />
+      </Cluster>
+{% endfor %}
+{% else %}
       <!--
       <Cluster className="org.apache.catalina.ha.tcp.SimpleTcpCluster"/>
       -->
+{% endif %}
 
       <!-- Use the LockOutRealm to prevent attempts to guess user passwords
            via a brute-force attack -->

--- a/roles/tomcat/templates/server.xml.j2
+++ b/roles/tomcat/templates/server.xml.j2
@@ -115,7 +115,7 @@
       <!--For clustering, please take a look at documentation at:
           /docs/cluster-howto.html  (simple how to)
           /docs/config/cluster.html (reference documentation) -->
-{% if cluster_mode %}
+{% if tomcat_cluster_mode %}
 {% for cluster in tomcat_cluster %}
       <Cluster className="org.apache.catalina.ha.tcp.SimpleTcpCluster"
 {% if cluster.channel_send_options is defined %}


### PR DESCRIPTION
Add configuration options to setup tomcat in cluster mode using StaticMembershipInterceptor class.
More info about the configuration can be found in RCIAM-271 ticket.