### PR TITLE
WIP: Fixed notify and config-1.17.php.j2

### DIFF
--- a/roles/ssp/tasks/configure-common.yml
+++ b/roles/ssp/tasks/configure-common.yml
@@ -7,7 +7,7 @@
 #    force: yes
 #  become: true
 #  notify:
-#    - restart apache
+#    - restart webserver
 
 - name: Generate SHA-256 encrypted hash of SSP admin password
   script: "ssha256pwgen-{{ ssp_version }}.php {{ ssp_path }} {{ ssp_adminpassword }}"
@@ -49,7 +49,7 @@
     force: yes
   become: yes
   notify:
-    - restart apache
+    - restart webserver
 
 - name: Generate self-signed SP certificates
   command: openssl req -newkey rsa:2048 -new -x509 -days 3652 -subj "/CN={{ item.ssl_certificate_cn }}" -nodes -out sp-{{ item.name }}.crt -keyout sp-{{ item.name }}.key

--- a/roles/ssp/templates/config/config-1.17.php.j2
+++ b/roles/ssp/templates/config/config-1.17.php.j2
@@ -661,20 +661,6 @@ $config = [
      * ],
      *
      */
-{% if ssp_memcache_store_servers is defined %}
-    'memcache_store.servers' => [
-{% for group in ssp_memcache_store_servers %}
-        [
-{% for host in group %}
-            [
-                'hostname' => '{{ host }}',
-                'timeout' => 1,
-            ],
-{% endfor %}
-        ],
-{% endfor %}
-    ],
-{% endif %}
 
     /*
      * This value allows you to set a prefix for memcache-keys. The default


### PR DESCRIPTION
- A notify hander fix in `roles/ssp/tasks/configure-common.yml`
- Fix `config-1.17.php.j2` template file.

---

### About `configure-common.yml

```bash
ERROR! The requested handler 'restart apache' was not found in either the main handlers list nor in the listening handlers list
```



### About `config-1.17.php.j2`

<details>
  <summary> Ansible FAILED </summary>

```bash
TASK [ssp : Configure SSP] ***************************************************************************
task path: /........../rciam-deploy/roles/ssp/tasks/configure-common.yml:44

<snf-xxXxx.ok-kno.grnetcloud.net> ESTABLISH SSH CONNECTION FOR USER: debian
[...]

fatal: [snf-xxXxx.ok-kno.grnetcloud.net]: FAILED! => {
    "changed": false,
    "msg": "AnsibleUndefinedVariable: list object has no element 1"
}
```
</details>

I think the problem is here [devel/roles/ssp/tasks/configure-common.yml](https://github.com/rciam/rciam-deploy/blob/devel/roles/ssp/tasks/configure-common.yml#L44-L52).

If I remove this [devel/roles/ssp/templates/config/config-1.17.php.j2](https://github.com/rciam/rciam-deploy/blob/devel/roles/ssp/templates/config/config-1.17.php.j2#L664-L677) from the template:
```
{% if ssp_memcache_store_servers is defined %}
    'memcache_store.servers' => [
{% for group in ssp_memcache_store_servers %}
        [
{% for host in group %}
            [
                'hostname' => '{{ host }}',
                'timeout' => 1,
            ],
{% endfor %}
        ],
{% endfor %}
    ],
{% endif %}
```

The role seems to be running smoothly, but we need to better investigate what the problem is here.