### PR TITLE
Dynamic find of "memcache_store.servers".

### DIFF
--- a/roles/ssp/templates/config/config-1.17.php.j2
+++ b/roles/ssp/templates/config/config-1.17.php.j2
@@ -660,7 +660,15 @@ $config = [
      *     ],
      * ],
      *
+     *
+     * One or more memcached server groups for storing session information when
+     * ssp_store_type is set to `memcache`. Every session data item will be mirrored
+     * in every server group. Each server group is a list of servers. The data items
+     * will be load-balanced between all servers in each server group.
+     *
      */
+
+{# Static behaviour #}
 {% if ssp_memcache_store_servers is defined %}
     'memcache_store.servers' => [
 {% for group in ssp_memcache_store_servers %}
@@ -671,6 +679,20 @@ $config = [
                 'timeout' => 1,
             ],
 {% endfor %}
+        ],
+{% endfor %}
+    ],
+{% endif %}
+
+{# Dynamic way #}
+{% if ssp_memcache_store_servers_group is defined and ssp_memcache_store_servers_group in group_names %}
+    'memcache_store.servers' => [
+{% for host in groups[ssp_memcache_store_servers_group] %}
+        [
+            [
+                'hostname' => '{{ lookup('dig', host) }}',
+                'timeout' => 1,
+            ],
         ],
 {% endfor %}
     ],


### PR DESCRIPTION
- [X] It does not matter if it is one, two or more.
- [X] Now the variable `ssp_memcache_store_servers` in the `rciam-deploy-inv/eosc-portal-demo/group_vars/saml2saml/ssp.yml` does not need it.


### About `config-1.17.php.j2`

It all started from this tasks [devel/roles/ssp/tasks/configure-common.yml](https://github.com/rciam/rciam-deploy/blob/devel/roles/ssp/tasks/configure-common.yml#L44-L52), with this template [devel/roles/ssp/templates/config/config-1.17.php.j2](https://github.com/rciam/rciam-deploy/blob/devel/roles/ssp/templates/config/config-1.17.php.j2#L664-L677) :
```
{% if ssp_memcache_store_servers is defined %}
    'memcache_store.servers' => [
{% for group in ssp_memcache_store_servers %}
        [
{% for host in group %}
            [
                'hostname' => '{{ host }}',
                'timeout' => 1,
            ],
{% endfor %}
        ],
{% endfor %}
    ],
{% endif %}
```

If in `rciam-deploy-inv/eosc-portal-demo/hosts.ini` there was _only one entry_ below the group `cache` then I get the following error:

<details>
  <summary> Ansible FAILED </summary>

```bash
TASK [ssp : Configure SSP] ***************************************************************************
task path: /........../rciam-deploy/roles/ssp/tasks/configure-common.yml:44

<snf-xxXxx.ok-kno.grnetcloud.net> ESTABLISH SSH CONNECTION FOR USER: debian
[...]

fatal: [snf-xxXxx.ok-kno.grnetcloud.net]: FAILED! => {
    "changed": false,
    "msg": "AnsibleUndefinedVariable: list object has no element 1"
}
```
</details>

**Now this has become more dynamic.**

-------

With two :
```yaml
[cache]
snf-xxXxx.ok-kno.grnetcloud.net
snf-xxXxx.ok-kno.grnetcloud.net
```


Before `/srv/simplesamlphp/proxy/config//config.php`: 655-668 :
```bash
    'memcache_store.servers' => [
        [
            [
                'hostname' => '8*.***.***.***',
                'timeout' => 1,
            ],
        ],
        [
            [
                'hostname' => '8*.***.***.***',
                'timeout' => 1,
            ],
        ],
    ],
```




Now `/srv/simplesamlphp/proxy/config//config.php`: 655-668 :

```bash
    'memcache_store.servers' => [
        [
            [
                'hostname' => '8*.***.***.***',
                'timeout' => 1,
            ],
        ],
        [
            [
                'hostname' => '8*.***.***.***',
                'timeout' => 1,
            ],
        ],
    ],
```



Now with **only one!**
```yaml
[cache]
snf-xxXxx.ok-kno.grnetcloud.net
snf-xxXxx.ok-kno.grnetcloud.net
```

* `/srv/simplesamlphp/proxy/config//config.php`:
```
    'memcache_store.servers' => [
        [
            [
                'hostname' => '8*.***.***.***',
                'timeout' => 1,
            ],
        ],
    ],
```

