### PR TITLE
Fix dynamic way for SSP memcache servers.

### DIFF
--- a/roles/ssp/templates/config/config-1.17.php.j2
+++ b/roles/ssp/templates/config/config-1.17.php.j2
@@ -682,10 +682,8 @@ $config = [
         ],
 {% endfor %}
     ],
-{% endif %}
-
 {# Dynamic way #}
-{% if ssp_memcache_store_servers_group is defined and ssp_memcache_store_servers_group in group_names %}
+{% elif ssp_memcache_store_servers_group is defined and ssp_memcache_store_servers_group in group_names %}
     'memcache_store.servers' => [
 {% for host in groups[ssp_memcache_store_servers_group] %}
         [


### PR DESCRIPTION
Follow the dynamic way only when the variable `ssp_memcache_store_servers` does not exist.