### PR TITLE
Multiple versions of SimpleSAMLphp.

### DIFF
--- a/roles/ssp/defaults/main.yml
+++ b/roles/ssp/defaults/main.yml
@@ -19,6 +19,10 @@ ssp_loggingdir: "{{ ssp_path }}/log/"
 ssp_datadir: "{{ ssp_path }}/data/"
 ssp_metadatadir: "{{ ssp_path }}/metadata/"
 
+# If you want specific path ( individual for different-multiple versions )
+# ssp_version_suffix: "{{ ssp_repo_version }}"
+ssp_www_path: "{{ ssp_path }}/../simplesaml-current"
+
 # Security configuration options
 
 # Secret salt used by SimpleSAMLphp when it needs to generate a secure hash of

--- a/roles/ssp/handlers/main.yml
+++ b/roles/ssp/handlers/main.yml
@@ -5,3 +5,12 @@
     name: "{{ ssp_webserver }}"
     state: restarted
   become: yes
+
+
+- name: Update symbolic link to SSP
+  file:
+    src: "{{ ssp_path }}/www/"
+    dest: "{{ ssp_www_path }}"
+    state: link
+  become: yes
+

--- a/roles/ssp/tasks/configure-common.yml
+++ b/roles/ssp/tasks/configure-common.yml
@@ -12,6 +12,7 @@
   become: yes
   notify:
     - restart webserver
+    - Update symbolic link to SSP
   tags:
     - ssp:config:config
 
@@ -297,3 +298,5 @@
   tags:
     - ssp:config:mods
     - ssp:config:mods:discopower
+
+

--- a/roles/ssp/tasks/install-common.yml
+++ b/roles/ssp/tasks/install-common.yml
@@ -1,5 +1,6 @@
 ---
 
+
 - name: Checkout SSP source
   git:
     repo: "{{ ssp_repo_url }}"
@@ -9,6 +10,8 @@
     force: no
     update: no
   become: yes
+  notify:
+    - Update symbolic link to SSP
 
 - name: Download Composer
   get_url: url=https://getcomposer.org/installer dest={{ ssp_path }}/composer-installer validate_certs=no
@@ -50,3 +53,6 @@
 - name: Ensure SSP cert dir exists
   file: path={{ ssp_certdir }} state=directory
   become: yes
+
+
+

--- a/roles/ssp/tasks/main.yml
+++ b/roles/ssp/tasks/main.yml
@@ -37,6 +37,15 @@
   tags:
     - always
 
+
+- name: Define SSP path
+  set_fact:
+    ssp_path: "{{ ssp_path }}-{{ ssp_version_suffix }}"
+  when: ssp_version_suffix is defined and ssp_version_suffix != ""
+  tags:
+    - always
+
+
 # Install OS-specific packages
 - include: install-Debian.yml
   when: ansible_os_family == 'Debian'


### PR DESCRIPTION
* [X] We can now safely install multiple versions of SSP on the same machine.

If `ssp_version_suffix` is defined, the ssp directory name will have a specific **suffix**.
In addition, a symbolic link in `/srv/simplesamlphp/proxy-current` to `/srv/simplesamlphp/proxy-example-dir/www/` will now be created.
This way we will have a fixed link file `/srv/simplesamlphp/proxy-current` which will redirect to the version of the SSP we want each time.
The web server now only needs to have this DocumentRoot : `/srv/simplesamlphp/proxy-current`.

* :link: https://github.com/grnet/rciam-deploy-inv/pull/32
* :link: https://github.com/grnet/rciam-deploy-inv/pull/34