### PR TITLE
Add restart interval

### DIFF
--- a/roles/fedreg-agent/templates/deployer_mitreid.service.j2
+++ b/roles/fedreg-agent/templates/deployer_mitreid.service.j2
@@ -7,6 +7,7 @@ Description=MitreId deployer service
 User=root
 ExecStart={{ fedreg_agent_venv_path }}/bin/deployer_mitreid -c {{ fedreg_agent_conf_dir }}/deployer_mitreid.config
 Restart=always
+RestartSec=60s
 Type=simple
 
 [Install]

--- a/roles/fedreg-agent/templates/deployer_ssp.service.j2
+++ b/roles/fedreg-agent/templates/deployer_ssp.service.j2
@@ -7,6 +7,7 @@ Description=SSP deployer service
 User=root
 ExecStart={{ fedreg_agent_venv_path }}/bin/deployer_ssp -c {{ fedreg_agent_conf_dir }}/deployer_ssp.config
 Restart=always
+RestartSec=60s
 Type=simple
 
 [Install]


### PR DESCRIPTION
Add restart interval in the service files as this caused problem when the deployers were exiting with an error.
The problem was that the service tried to restart too soon and caused the service to crash