### PR TITLE
Extend_ssp_authsources_template

### DIFF
--- a/roles/ssp/defaults/main.yml
+++ b/roles/ssp/defaults/main.yml
@@ -209,12 +209,23 @@ ssp_authproc_sp:
       # Adopts language from attribute to use in UI
       class: "core:LanguageAdaptor"
 
+# This will be added before the config[] in SimpleSAMLphp authentication sources
+#ssp_authsources_preamble: |
+#   function foo() {
+#     // Do something
+#   }
+
 ssp_authsources_saml:
   # Additional properties: `entity_id`, `idp`.
   - name: default-sp
-    # Uncomment to use the discopower module that provides a more user-friendly
-    # IdP discovery service compared to the default.
-    # Requires `discopower` module in `ssp_mods_enabled` (see below).
+    # Uncomment to specify the entity ID of the IdP this should SP should
+    # contact. If this is not set, the user will be shown a list of available
+    # IdPs.
+    # idp: "https://idp.example.org
+    # Uncomment to specify the function returning the entity ID of the IdP
+    # this SP should contact. When NULL the user will be shown a list of
+    # available IdPs.
+    # idp_function: "findIdP()"
     #disco_url: "/{{ ssp_alias }}/module.php/discopower/disco.php"
     # Set to true to generate self-signed SSL certificate for signing requests/
     # response received from/sent to the IdP, as well as for receiving encrypted

--- a/roles/ssp/templates/config/authsources-1.14.php.j2
+++ b/roles/ssp/templates/config/authsources-1.14.php.j2
@@ -4,6 +4,10 @@
  * {{ ansible_managed }}
  */
 
+{% if ssp_authsources_preamble is defined %}
+{{ ssp_authsources_preamble }}
+{% endif %}
+
 $config = array(
 
     // This is a authentication source which handles admin authentication.
@@ -22,7 +26,11 @@ $config = array(
         // Can be NULL/unset, in which case an entity ID is generated based on the metadata URL.
         'entityID' => '{{ authsource.entity_id }}',
 {% endif %}
-{% if authsource.idp is defined %}
+{% if authsource.idp_function is defined %}
+        // The function returning the entity ID of the IdP this SP should contact.
+        // Can be NULL/unset, in which case the user will be shown a list of available IdPs.
+        'idp' => {{ authsource.idp_function }},
+{% elif authsource.idp is defined %}
         // The entity ID of the IdP this should SP should contact.
         // Can be NULL/unset, in which case the user will be shown a list of available IdPs.
         'idp' => '{{ authsource.idp }}',

--- a/roles/ssp/templates/config/authsources-1.17.php.j2
+++ b/roles/ssp/templates/config/authsources-1.17.php.j2
@@ -4,6 +4,10 @@
  * {{ ansible_managed }}
  */
 
+{% if ssp_authsources_preamble is defined %}
+{{ ssp_authsources_preamble }}
+{% endif %}
+
 $config = [
 
     // This is a authentication source which handles admin authentication.
@@ -22,7 +26,11 @@ $config = [
         // Can be NULL/unset, in which case an entity ID is generated based on the metadata URL.
         'entityID' => '{{ authsource.entity_id }}',
 {% endif %}
-{% if authsource.idp is defined %}
+{% if authsource.idp_function is defined %}
+        // The function returning the entity ID of the IdP this SP should contact.
+        // Can be NULL/unset, in which case the user will be shown a list of available IdPs.
+        'idp' => {{ authsource.idp_function }},
+{% elif authsource.idp is defined %}
         // The entity ID of the IdP this should SP should contact.
         // Can be NULL/unset, in which case the user will be shown a list of available IdPs.
         'idp' => '{{ authsource.idp }}',

--- a/roles/ssp/templates/config/authsources-1.18.php.j2
+++ b/roles/ssp/templates/config/authsources-1.18.php.j2
@@ -4,6 +4,10 @@
  * {{ ansible_managed }}
  */
 
+{% if ssp_authsources_preamble is defined %}
+{{ ssp_authsources_preamble }}
+{% endif %}
+
 $config = [
 
     // This is a authentication source which handles admin authentication.
@@ -22,7 +26,11 @@ $config = [
         // Can be NULL/unset, in which case an entity ID is generated based on the metadata URL.
         'entityID' => '{{ authsource.entity_id }}',
 {% endif %}
-{% if authsource.idp is defined %}
+{% if authsource.idp_function is defined %}
+        // The function returning the entity ID of the IdP this SP should contact.
+        // Can be NULL/unset, in which case the user will be shown a list of available IdPs.
+        'idp' => {{ authsource.idp_function }},
+{% elif authsource.idp is defined %}
         // The entity ID of the IdP this should SP should contact.
         // Can be NULL/unset, in which case the user will be shown a list of available IdPs.
         'idp' => '{{ authsource.idp }}',


### PR DESCRIPTION
Extend SSP authsources.php.j2 template in order to support raw php