### PR TITLE
Cronjobs_run_once_comanage_registry_role

### DIFF
--- a/roles/comanage-registry-plugins/defaults/main.yml
+++ b/roles/comanage-registry-plugins/defaults/main.yml
@@ -8,7 +8,7 @@ comanage_registry_plugins: []
 #    status: init
 
 
-#comanage_cron_jobs:
+#comanage_plugins_cron_jobs:
 #  - name: "Action Name"
 #    minute: "0"
 #    filename: "PluginName"
@@ -19,3 +19,6 @@ comanage_registry_plugins: []
 #comanage_symlinks:
 #  - target: "/path/to/target"
 #    link: "/path/to/symlink"
+
+# Whether to install COmanage plugins cron jobs; Enabled by default
+comanage_plugins_cron_jobs_enabled: yes

--- a/roles/comanage-registry-plugins/tasks/configure.yml
+++ b/roles/comanage-registry-plugins/tasks/configure.yml
@@ -12,9 +12,9 @@
     user: "{{ item.user }}"
     cron_file: "{{ item.filename }}"
     backup: true
-  loop: "{{ comanage_cron_jobs | default([]) }}"
+  loop: "{{ comanage_plugins_cron_jobs | default([]) }}"
   become: true
-  when: comanage_cron_jobs is defined
+  when: comanage_plugins_cron_jobs is defined and comanage_plugins_cron_jobs_enabled
 
 - name: Create Symbolic links
   file:

--- a/roles/comanage-registry/defaults/main.yml
+++ b/roles/comanage-registry/defaults/main.yml
@@ -151,5 +151,5 @@ comanage_ldap_provisioner_entitlements:
 #    job: |
 #      cd {{ path_to_registry }}/app && Console/cake action
 
-# Whether to install RCIAM util cron jobs; Enabled by default
+# Whether to install COmanage cron jobs; Enabled by default
 comanage_cron_jobs_enabled: yes

--- a/roles/comanage-registry/defaults/main.yml
+++ b/roles/comanage-registry/defaults/main.yml
@@ -150,3 +150,6 @@ comanage_ldap_provisioner_entitlements:
 #    user: root
 #    job: |
 #      cd {{ path_to_registry }}/app && Console/cake action
+
+# Whether to install RCIAM util cron jobs; Enabled by default
+comanage_cron_jobs_enabled: yes

--- a/roles/comanage-registry/tasks/configure.yml
+++ b/roles/comanage-registry/tasks/configure.yml
@@ -126,7 +126,7 @@
     backup: true
   loop: "{{ comanage_cron_jobs | default([]) }}"
   become: true
-  when: comanage_cron_jobs is defined
+  when: comanage_cron_jobs is defined and comanage_cron_jobs_enabled
 
 # Tasks adding/copying/replacing files
 - name: Update/Copy tasks


### PR DESCRIPTION
Cron jobs deploy only in one node