### PR TITLE
IdP and federation role config now allows updates on subsequent executions

### DIFF
--- a/roles/keycloak/tasks/blocks/configure_federations.yml
+++ b/roles/keycloak/tasks/blocks/configure_federations.yml
@@ -3,6 +3,20 @@
 - name: "Get current list of federations of the realm: {{item[0].name}}"
   include_tasks: blocks/helpers/get_realm_federations.yml
 
+- set_fact:
+    exists: true
+    additional_info:
+      internalId: "{{realm_federation_matches[0].internalId}}"
+  when: "{{ realm_federation_matches | length > 0 }}"
+
+- set_fact:
+    body: "{{ item[1] | combine(additional_info , recursive=True ) }}"
+  when: exists
+
+- set_fact:
+    body: "{{ item[1] }}"
+  when: not exists
+
 
 - name: "Configuring federation: {{item[1].alias}}"
   block:
@@ -15,8 +29,6 @@
         headers:
           Authorization: "Bearer {{ result.json.access_token }}"
         body:
-          "{{ item[1] }}"
+          "{{body}}"
         status_code: 201
-
-  when: "item[1].alias not in realm_federations"
 

--- a/roles/keycloak/tasks/blocks/configure_federations.yml
+++ b/roles/keycloak/tasks/blocks/configure_federations.yml
@@ -4,18 +4,20 @@
   include_tasks: blocks/helpers/get_realm_federations.yml
 
 - set_fact:
-    exists: true
+    federation_exists: "{{realm_federation_matches | length > 0 }}"
+
+- set_fact:
     additional_info:
       internalId: "{{realm_federation_matches[0].internalId}}"
-  when: "{{ realm_federation_matches | length > 0 }}"
+  when: federation_exists
 
 - set_fact:
     body: "{{ item[1] | combine(additional_info , recursive=True ) }}"
-  when: exists
+  when: federation_exists
 
 - set_fact:
     body: "{{ item[1] }}"
-  when: not exists
+  when: not federation_exists
 
 
 - name: "Configuring federation: {{item[1].alias}}"

--- a/roles/keycloak/tasks/blocks/configure_saml_idps.yml
+++ b/roles/keycloak/tasks/blocks/configure_saml_idps.yml
@@ -3,7 +3,10 @@
 - name: "Get current IdPs list of realm: {{item[0].name}}"
   include_tasks: blocks/helpers/get_realm_idps_list.yml
 
-- name: "Installing saml IdP: {{item[1].data.alias}}"
+- set_fact:
+    new_idp: "{% if item[1].data.alias not in idps_list %}true{% else %}false{% endif %}"
+
+- name: "{% if new_idp %}Installing{% else %}Updating{% endif %} saml IdP: {{item[1].data.alias}}"
   block:
     - name: "Get config from url: {{ item[1].metadataUrl }}"
       uri:
@@ -20,12 +23,11 @@
 
     - name: "Setup saml IdP {{ item[1].data.alias }}"
       uri:
-        url: "https://{{ keycloak_proxy_host }}/auth/admin/realms/{{ item[0].name }}/identity-provider/instances"
-        method: POST
+        url: "https://{{ keycloak_proxy_host }}/auth/admin/realms/{{ item[0].name }}/identity-provider/instances{% if new_idp %}{% else %}/{{item[1].data.alias}}{% endif %}"
+        method: "{% if new_idp %}POST{% else %}PUT{% endif %}"
         body_format: json
         headers:
           Authorization: "Bearer {{ result.json.access_token }}"
         body:
           "{{ { 'config': saml_idp_result.json } | combine( item[1].data, recursive=True ) }}"
-        status_code: 201
-  when: "item[1].data.alias not in idps_list"
+        status_code: "{% if new_idp %}201{% else %}204{% endif %}"

--- a/roles/keycloak/tasks/blocks/configure_social_idps.yml
+++ b/roles/keycloak/tasks/blocks/configure_social_idps.yml
@@ -3,14 +3,16 @@
 - name: "Configuring IdP: {{item[1].alias}} Get current IdPs list for realm: {{item[0].name}}"
   include_tasks: blocks/helpers/get_realm_idps_list.yml
 
-- name: "Add idp: {{ item[1].alias }}"
+- set_fact:
+    new_idp: "{% if item[1].alias not in idps_list %}true{% else %}false{% endif %}"
+
+- name: "{% if new_idp %}Add{% else %}Update{% endif %} idp: {{ item[1].alias }}"
   uri:
-    url: "https://{{ keycloak_proxy_host }}/auth/admin/realms/{{ item[0].name }}/identity-provider/instances"
-    method: POST
+    url: "https://{{ keycloak_proxy_host }}/auth/admin/realms/{{ item[0].name }}/identity-provider/instances{% if new_idp %}{% else %}/{{item[1].alias}}{% endif %}"
+    method: "{% if new_idp %}POST{% else %}PUT{% endif %}"
     body_format: json
     headers:
       Authorization: "Bearer {{ result.json.access_token }}"
     body:
       "{{item[1]}}"
-    status_code: 201
-  when: "item[1].alias not in idps_list"
+    status_code: "{% if new_idp %}201{% else %}204{% endif %}"

--- a/roles/keycloak/tasks/blocks/helpers/get_realm_federations.yml
+++ b/roles/keycloak/tasks/blocks/helpers/get_realm_federations.yml
@@ -10,4 +10,7 @@
   register: "realm_result"
 
 - set_fact:
-    realm_federations: "{{realm_result.json.identityProvidersFederations | json_query('[].alias') | default([]) }}"
+    realm_federation_matches: "{{realm_result.json.identityProvidersFederations | json_query(query) | default([]) }}"
+  vars:
+    query: '[?alias == `{{ item[1].alias }}` ].{alias: alias, internalId: internalId }'
+


### PR DESCRIPTION
Changed the role to allow updating all  idps and federations, on subsequest calls with a different config