### PR TITLE
[keycloak role] - minor loop bordercase fix

### DIFF
--- a/roles/keycloak/tasks/blocks/configure_federations.yml
+++ b/roles/keycloak/tasks/blocks/configure_federations.yml
@@ -54,7 +54,7 @@
 
     - name: Setup federation mapper
       include_tasks: blocks/configure_federation_mapper.yml
-      with_items: "{{ item[1].mappers }}"
+      with_items: "{{ item[1].mappers | default([]) }}"
       loop_control:
         loop_var: mapper
       run_once: true


### PR DESCRIPTION
Skip configuring the federation's mappers if none (federation mappers) are defined. 