### PR TITLE
Rciam 793 and 814

### DIFF
--- a/roles/keycloak/tasks/blocks/configure_client_scopes.yml
+++ b/roles/keycloak/tasks/blocks/configure_client_scopes.yml
@@ -44,7 +44,7 @@
   when: not client_scope_exists
 
 
-- name: "Clear from all the default client scopes list (iff applicable)"
+- name: "Clear from all the default client scopes list (if applicable)"
   uri:
     url: "{{ keycloak_proxy_host }}/admin/realms/{{ item[0].name }}/default-{{ client_scope_mode }}-client-scopes/{{ client_scope_matches[0].id }}"
     method: "DELETE"

--- a/roles/keycloak/tasks/blocks/configure_client_scopes.yml
+++ b/roles/keycloak/tasks/blocks/configure_client_scopes.yml
@@ -44,37 +44,31 @@
   when: not client_scope_exists
 
 
+- name: "Clear from all the default client scopes list (iff applicable)"
+  uri:
+    url: "{{ keycloak_proxy_host }}/admin/realms/{{ item[0].name }}/default-{{ client_scope_mode }}-client-scopes/{{ client_scope_matches[0].id }}"
+    method: "DELETE"
+    headers:
+      Authorization: "Bearer {{ tokens.json.access_token }}"
+    status_code: "204"
+  with_items:
+    - optional
+    - default
+  loop_control:
+    loop_var: client_scope_mode
+  ignore_errors: yes
 
 # set default or optional (if defined)
-- name: "Configuring default/optional client-scope (tasks block)"
-  block:
-
-    - name: "Clear the default client scopes list"
-      uri:
-        url: "{{ keycloak_proxy_host }}/admin/realms/{{ item[0].name }}/default-{{ client_scope_mode }}-client-scopes/{{ client_scope_matches[0].id }}"
-        method: "DELETE"
-        headers:
-          Authorization: "Bearer {{ tokens.json.access_token }}"
-        status_code: "204"
-      with_items:
-        - optional
-        - default
-      loop_control:
-        loop_var: client_scope_mode
-      ignore_errors: yes
-
-    - name: "Setting the client scope as '{{ item[1].set_as }}'"
-      uri:
-        url: "{{ keycloak_proxy_host }}/admin/realms/{{ item[0].name }}/default-{{ item[1].set_as }}-client-scopes/{{ client_scope_matches[0].id }}"
-        method: "PUT"
-        body_format: json
-        headers:
-          Authorization: "Bearer {{ tokens.json.access_token }}"
-        body:
-          { realm: "{{ item[0].name }}", clientScopeId: "{{ client_scope_matches[0].id }}" }
-        status_code: "204"
-
-
+- name: "Configuring default/optional client-scope as '{{ item[1].set_as }}'"
+  uri:
+    url: "{{ keycloak_proxy_host }}/admin/realms/{{ item[0].name }}/default-{{ item[1].set_as }}-client-scopes/{{ client_scope_matches[0].id }}"
+    method: "PUT"
+    body_format: json
+    headers:
+      Authorization: "Bearer {{ tokens.json.access_token }}"
+    body:
+      { realm: "{{ item[0].name }}", clientScopeId: "{{ client_scope_matches[0].id }}" }
+    status_code: "204"
   when: not item[1].set_as is undefined
 
 

--- a/roles/keycloak/tasks/blocks/helpers/unassign_default_client_scopes.yml
+++ b/roles/keycloak/tasks/blocks/helpers/unassign_default_client_scopes.yml
@@ -1,0 +1,37 @@
+---
+
+- include_tasks: blocks/helpers/get_tokens.yml
+
+- name: "Get all default optional client-scopes list"
+  uri:
+    url: "{{ keycloak_proxy_host }}/admin/realms/{{ current_realm.name }}/default-optional-client-scopes"
+    method: "GET"
+    headers:
+      Authorization: "Bearer {{ tokens.json.access_token }}"
+    status_code: "200"
+  register: "default_optional_list"
+
+- name: "Clear all from the default optional client scopes list"
+  include_tasks: blocks/helpers/unassign_default_optional_client_scope.yml
+  with_items: "{{ default_optional_list.json | default([]) }}"
+  loop_control:
+    loop_var: current_default_optional
+
+
+- include_tasks: blocks/helpers/get_tokens.yml
+
+- name: "Get all default default client-scopes list"
+  uri:
+    url: "{{ keycloak_proxy_host }}/admin/realms/{{ current_realm.name }}/default-default-client-scopes"
+    method: "GET"
+    headers:
+      Authorization: "Bearer {{ tokens.json.access_token }}"
+    status_code: "200"
+  register: "default_default_list"
+
+
+- name: "Clear all from the default default client scopes list"
+  include_tasks: blocks/helpers/unassign_default_default_client_scope.yml
+  with_items: "{{ default_default_list.json | default([]) }}"
+  loop_control:
+    loop_var: current_default_default

--- a/roles/keycloak/tasks/blocks/helpers/unassign_default_default_client_scope.yml
+++ b/roles/keycloak/tasks/blocks/helpers/unassign_default_default_client_scope.yml
@@ -1,0 +1,11 @@
+---
+
+- include_tasks: blocks/helpers/get_tokens.yml
+
+- name: "Clear {{ current_default_default.name }} from the default default client scopes list"
+  uri:
+    url: "{{ keycloak_proxy_host }}/admin/realms/{{ current_realm.name }}/default-default-client-scopes/{{ current_default_default.id }}"
+    method: "DELETE"
+    headers:
+      Authorization: "Bearer {{ tokens.json.access_token }}"
+    status_code: "204"

--- a/roles/keycloak/tasks/blocks/helpers/unassign_default_optional_client_scope.yml
+++ b/roles/keycloak/tasks/blocks/helpers/unassign_default_optional_client_scope.yml
@@ -1,0 +1,11 @@
+---
+
+- include_tasks: blocks/helpers/get_tokens.yml
+
+- name: "Clear {{ current_default_optional.name }} from the default optional client scopes list"
+  uri:
+    url: "{{ keycloak_proxy_host }}/admin/realms/{{ current_realm.name }}/default-optional-client-scopes/{{ current_default_optional.id }}"
+    method: "DELETE"
+    headers:
+      Authorization: "Bearer {{ tokens.json.access_token }}"
+    status_code: "204"

--- a/roles/keycloak/tasks/configure.yml
+++ b/roles/keycloak/tasks/configure.yml
@@ -140,13 +140,22 @@
       loop_control:
         loop_var: current_realm
 
-    - name: Setup client scopes
-      include_tasks: blocks/configure_client_scopes.yml
-      with_subelements:
-        - "{{config.realms | default([])}} "
-        - "client_scopes"
-        - skip_missing: True
-      run_once: true
+    - name: "Setup client scopes (block)"
+      block:
+        - name: "Clear all assigned default and optional client scopes"
+          include_tasks: blocks/helpers/unassign_default_client_scopes.yml
+          with_items: "{{ keycloak_config.realms | default([]) }}"
+          loop_control:
+            loop_var: current_realm
+          run_once: true
+
+        - name: Setup client scopes
+          include_tasks: blocks/configure_client_scopes.yml
+          with_subelements:
+            - "{{keycloak_config.realms | default([])}} "
+            - "client_scopes"
+            - skip_missing: True
+          run_once: true
 
   tags: "keycloak:config:realm_configuration"
 


### PR DESCRIPTION
This PR is an update of [RCIAM-793](https://jira.argo.grnet.gr/browse/RCIAM-793) to be able to assign client scopes into default and optional categories, in order to be able to apply the requirements of [RCIAM-814](https://jira.argo.grnet.gr/browse/RCIAM-814)