### PR TITLE
[keycloak role] Changes the realm creation/update to be more generic and enables realm roles management   

### DIFF
--- a/roles/keycloak/defaults/main.yml
+++ b/roles/keycloak/defaults/main.yml
@@ -230,20 +230,6 @@ keycloak_java_opts: "-Xms1024m -Xmx2048m -XX:MaxPermSize=768m"
 #        defaultAction: true
 #        reset_every: 165  # it goes (reset_every * reset_every_multiplier) seconds
 #        reset_every_multiplier: 3600 # use 3600 for hours, 86400 for days
-#      smtp:
-#        host: "smtp.example.com"
-#        from_email: "noreply@example.com"
-#        port: 25
-#        ## values below are optional
-#        enable_ssl: true
-#        enable_starttls: true
-#        from_name: ""
-#        reply_to_name: ""
-#        reply_to_email: ""
-#        envelope_from: ""
-#        auth_enabled: false
-#        auth_username: ""
-#        auth_password: ""
 #      client_scopes:
 #        - name: "dummy"
 #          description: "this is a dummy one"

--- a/roles/keycloak/defaults/main.yml
+++ b/roles/keycloak/defaults/main.yml
@@ -38,48 +38,48 @@ keycloak_bind_port: "8080"
 keycloak_java_opts: "-Xms1024m -Xmx2048m -XX:MaxPermSize=768m"
 
 
-## plugins
-## wayf plugin works ONLY with "stage" branch of keycloak (need to have commit fe055820980dbcb79d5aae2b4dce78b840b912b0)
-keycloak_plugins:
-  wayf:
-    enabled: true
-    name: "keycloak-theme-vanilla" #PLEASE, do not change this
-    module:
-      jar_url: "<location of plugin jar>"
-      modulexml_url: "https://raw.githubusercontent.com/eosc-kc/keycloak-theme-vanilla/master/module.xml"
-    theme:
-      name: "rciam"
-      add_to_realms:
-        - "master"
-    theme:
-      name: "rciam"
-      add_to_realms:
-        - name: "demo"
-          terms: "{{ lookup('file', inventory_dir + '/group_vars/keycloak/terms/einfra.html') }}"
-          config:
-            ribbonText:
-              - "Demo"
-            htmlFooterText:
-              - "Copyright © 2021-2022"
-            supportUrl:
-              - "eid-support@einfra.grnet.gr"
-            privacyPolicyUrl:
-              - "https://eid-proxy.aai-dev.grnet.gr/static/privacy-policy.pdf"
-  idp_hashedid_mapper:
-    enabled: true
-    name: "keycloak-idp-hashedId-mapper" #PLEASE, do not change this
-    module:
-      jar_url: "<location of plugin jar>"
-      modulexml_url: "https://raw.githubusercontent.com/eosc-kc/keycloak-idp-hashedId-mapper/master/module.xml"
-  orcid_idp:
-    enabled: true
-    name: "orcid-idp"
-    hotdeploy:
-      jar_url: "https://github.com/eosc-kc/keycloak-orcid/releases/download/1.0.0/keycloak-orcid-1.0.0.jar"
+### plugins
+### wayf plugin works ONLY with "stage" branch of keycloak (need to have commit fe055820980dbcb79d5aae2b4dce78b840b912b0)
+#keycloak_plugins:
+#  wayf:
+#    enabled: true
+#    name: "keycloak-theme-vanilla" #PLEASE, do not change this
+#    module:
+#      jar_url: "<location of plugin jar>"
+#      modulexml_url: "https://raw.githubusercontent.com/eosc-kc/keycloak-theme-vanilla/master/module.xml"
+#    theme:
+#      name: "rciam"
+#      add_to_realms:
+#        - "master"
+#    theme:
+#      name: "rciam"
+#      add_to_realms:
+#        - name: "demo"
+#          terms: "{{ lookup('file', inventory_dir + '/group_vars/keycloak/terms/einfra.html') }}"
+#          config:
+#            ribbonText:
+#              - "Demo"
+#            htmlFooterText:
+#              - "Copyright © 2021-2022"
+#            supportUrl:
+#              - "eid-support@einfra.grnet.gr"
+#            privacyPolicyUrl:
+#              - "https://eid-proxy.aai-dev.grnet.gr/static/privacy-policy.pdf"
+#  idp_hashedid_mapper:
+#    enabled: true
+#    name: "keycloak-idp-hashedId-mapper" #PLEASE, do not change this
+#    module:
+#      jar_url: "<location of plugin jar>"
+#      modulexml_url: "https://raw.githubusercontent.com/eosc-kc/keycloak-idp-hashedId-mapper/master/module.xml"
+#  orcid_idp:
+#    enabled: true
+#    name: "orcid-idp"
+#    hotdeploy:
+#      jar_url: "https://github.com/eosc-kc/keycloak-orcid/releases/download/1.0.0/keycloak-orcid-1.0.0.jar"
 
-## Remaining configuration (enc keys, social IdPs, AUP config, SMTP config, etc)
-## you can have more than one realms configured here (if it doesn't exist, it will be created). just copy the format of the master and add it in the list.
-## also, you can just comment out any of the {key, aup, smtp} sub trees and let the remaining get configured
+### Remaining configuration (enc keys, social IdPs, AUP config, SMTP config, etc)
+### you can have more than one realms configured here (if it doesn't exist, it will be created). just copy the format of the master and add it in the list.
+### also, you can just comment out any of the {key, aup, smtp} sub trees and let the remaining get configured
 #keycloak_config:
 #  realms:
 #    - name: master

--- a/roles/keycloak/defaults/main.yml
+++ b/roles/keycloak/defaults/main.yml
@@ -254,37 +254,37 @@ keycloak_java_opts: "-Xms1024m -Xmx2048m -XX:MaxPermSize=768m"
 #                multivalued: ""
 #                user.attribute: "attrib11"
 #                userinfo.token.claim: "true"
-      federations:
-        - providerId: "saml" # DO NOT CHANGE THIS!
-          url: "<THE URL OF THE FEDERATION's XML>"
-          alias: "<SET AN ALIAS>"
-          updateFrequencyInMins: 1440
-          config:
-            nameIDPolicyFormat: "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent"
-            principalType: "SUBJECT"
-            postBindingAuthnRequest: "true"
-            wantAuthnRequestsSigned: "true"
-            wantAssertionsSigned: "true"
-            wantAssertionsEncrypted: "true"
-            multiplePrincipals: "[{\"principalType\":\"SUBJECT\",\"nameIDPolicyFormat\":\"urn:oasis:names:tc:SAML:2.0:nameid-format:persistent\"}]"
-          entityIdWhiteList:
-            - "https://aaa.bbb.com/entity1"
-          entityIdBlackList:
-            - "https://aaa.bbb.com/entity2"
-          registrationAuthorityWhiteList:
-            - "registration-authority-1"
-          registrationAuthorityBlackList:
-            - "registration-authority-2"
-          categoryWhiteList:
-            attribute-name-1:
-              - "attribute-value-1"
-            attribute-name-2:
-              - "attribute-value-2"
-          categoryBlackList:
-            attribute-name-1:
-              - "attribute-value-1"
-            attribute-name-2:
-              - "attribute-value-2"
+#      federations:
+#        - providerId: "saml" # DO NOT CHANGE THIS!
+#          url: "<THE URL OF THE FEDERATION's XML>"
+#          alias: "<SET AN ALIAS>"
+#          updateFrequencyInMins: 1440
+#          config:
+#            nameIDPolicyFormat: "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent"
+#            principalType: "SUBJECT"
+#            postBindingAuthnRequest: "true"
+#            wantAuthnRequestsSigned: "true"
+#            wantAssertionsSigned: "true"
+#            wantAssertionsEncrypted: "true"
+#            multiplePrincipals: "[{\"principalType\":\"SUBJECT\",\"nameIDPolicyFormat\":\"urn:oasis:names:tc:SAML:2.0:nameid-format:persistent\"}]"
+#          entityIdWhiteList:
+#            - "https://aaa.bbb.com/entity1"
+#          entityIdBlackList:
+#            - "https://aaa.bbb.com/entity2"
+#          registrationAuthorityWhiteList:
+#            - "registration-authority-1"
+#          registrationAuthorityBlackList:
+#            - "registration-authority-2"
+#          categoryWhiteList:
+#            attribute-name-1:
+#              - "attribute-value-1"
+#            attribute-name-2:
+#              - "attribute-value-2"
+#          categoryBlackList:
+#            attribute-name-1:
+#              - "attribute-value-1"
+#            attribute-name-2:
+#              - "attribute-value-2"
 #          mappers:
 #            - name: "test_mapper"
 #              identityProviderMapper: hardcoded-attribute-idp-mapper

--- a/roles/keycloak/defaults/main.yml
+++ b/roles/keycloak/defaults/main.yml
@@ -80,11 +80,29 @@ keycloak_java_opts: "-Xms1024m -Xmx2048m -XX:MaxPermSize=768m"
 ### Remaining configuration (enc keys, social IdPs, AUP config, SMTP config, etc)
 ### you can have more than one realms configured here (if it doesn't exist, it will be created). just copy the format of the master and add it in the list.
 ### also, you can just comment out any of the {key, aup, smtp} sub trees and let the remaining get configured
-keycloak_config:
-  realms:
-    - name: master
-      verifyEmail: true
-      displayNameHtml: Keycloak
+#keycloak_config:
+#  realms:
+#    - name: master
+#      defaultIdPAlias: "" #setting this to an IdP's name, will skip the WAYF and redirect to that IdP
+#      config:
+#        enabled: true  #do not change this
+#        displayNameHtml: "<div class=\"kc-logo-text\"><span>Keycloak</span></div>"
+#        verifyEmail: true
+#        ssoSessionIdleTimeout: 31536000
+#        ssoSessionMaxLifespan: 34128000
+#        smtpServer:
+#          host: ""
+#          from: ""
+#          port: ""
+#          ssl: ""
+#          starttls: ""
+#          fromDisplayName: ""
+#          envelopeFrom: ""
+#          replyTo: ""
+#          replyToDisplayName: ""
+#          auth: "false"
+#          user: ""
+#          password: ""
 #      defaultIdPAlias: "" #setting this, will skip the WAYF and redirect to that IdP
 #      keys:
 #        - name: "rsa-sig"

--- a/roles/keycloak/defaults/main.yml
+++ b/roles/keycloak/defaults/main.yml
@@ -38,48 +38,48 @@ keycloak_bind_port: "8080"
 keycloak_java_opts: "-Xms1024m -Xmx2048m -XX:MaxPermSize=768m"
 
 
-### plugins
-### wayf plugin works ONLY with "stage" branch of keycloak (need to have commit fe055820980dbcb79d5aae2b4dce78b840b912b0)
-#keycloak_plugins:
-#  wayf:
-#    enabled: true
-#    name: "keycloak-theme-vanilla" #PLEASE, do not change this
-#    module:
-#      jar_url: "<location of plugin jar>"
-#      modulexml_url: "https://raw.githubusercontent.com/eosc-kc/keycloak-theme-vanilla/master/module.xml"
-#    theme:
-#      name: "rciam"
-#      add_to_realms:
-#        - "master"
-#    theme:
-#      name: "rciam"
-#      add_to_realms:
-#        - name: "demo"
-#          terms: "{{ lookup('file', inventory_dir + '/group_vars/keycloak/terms/einfra.html') }}"
-#          config:
-#            ribbonText:
-#              - "Demo"
-#            htmlFooterText:
-#              - "Copyright © 2021-2022"
-#            supportUrl:
-#              - "eid-support@einfra.grnet.gr"
-#            privacyPolicyUrl:
-#              - "https://eid-proxy.aai-dev.grnet.gr/static/privacy-policy.pdf"
-#  idp_hashedid_mapper:
-#    enabled: true
-#    name: "keycloak-idp-hashedId-mapper" #PLEASE, do not change this
-#    module:
-#      jar_url: "<location of plugin jar>"
-#      modulexml_url: "https://raw.githubusercontent.com/eosc-kc/keycloak-idp-hashedId-mapper/master/module.xml"
-#  orcid_idp:
-#    enabled: true
-#    name: "orcid-idp"
-#    hotdeploy:
-#      jar_url: "https://github.com/eosc-kc/keycloak-orcid/releases/download/1.0.0/keycloak-orcid-1.0.0.jar"
+## plugins
+## wayf plugin works ONLY with "stage" branch of keycloak (need to have commit fe055820980dbcb79d5aae2b4dce78b840b912b0)
+keycloak_plugins:
+  wayf:
+    enabled: true
+    name: "keycloak-theme-vanilla" #PLEASE, do not change this
+    module:
+      jar_url: "<location of plugin jar>"
+      modulexml_url: "https://raw.githubusercontent.com/eosc-kc/keycloak-theme-vanilla/master/module.xml"
+    theme:
+      name: "rciam"
+      add_to_realms:
+        - "master"
+    theme:
+      name: "rciam"
+      add_to_realms:
+        - name: "demo"
+          terms: "{{ lookup('file', inventory_dir + '/group_vars/keycloak/terms/einfra.html') }}"
+          config:
+            ribbonText:
+              - "Demo"
+            htmlFooterText:
+              - "Copyright © 2021-2022"
+            supportUrl:
+              - "eid-support@einfra.grnet.gr"
+            privacyPolicyUrl:
+              - "https://eid-proxy.aai-dev.grnet.gr/static/privacy-policy.pdf"
+  idp_hashedid_mapper:
+    enabled: true
+    name: "keycloak-idp-hashedId-mapper" #PLEASE, do not change this
+    module:
+      jar_url: "<location of plugin jar>"
+      modulexml_url: "https://raw.githubusercontent.com/eosc-kc/keycloak-idp-hashedId-mapper/master/module.xml"
+  orcid_idp:
+    enabled: true
+    name: "orcid-idp"
+    hotdeploy:
+      jar_url: "https://github.com/eosc-kc/keycloak-orcid/releases/download/1.0.0/keycloak-orcid-1.0.0.jar"
 
-### Remaining configuration (enc keys, social IdPs, AUP config, SMTP config, etc)
-### you can have more than one realms configured here (if it doesn't exist, it will be created). just copy the format of the master and add it in the list.
-### also, you can just comment out any of the {key, aup, smtp} sub trees and let the remaining get configured
+## Remaining configuration (enc keys, social IdPs, AUP config, SMTP config, etc)
+## you can have more than one realms configured here (if it doesn't exist, it will be created). just copy the format of the master and add it in the list.
+## also, you can just comment out any of the {key, aup, smtp} sub trees and let the remaining get configured
 #keycloak_config:
 #  realms:
 #    - name: master
@@ -103,7 +103,26 @@ keycloak_java_opts: "-Xms1024m -Xmx2048m -XX:MaxPermSize=768m"
 #          auth: "false"
 #          user: ""
 #          password: ""
-#      defaultIdPAlias: "" #setting this, will skip the WAYF and redirect to that IdP
+#      role_management:
+#        roles:
+#          - name: "student"
+#            description: "this is a blah blah"
+#            attributes:
+#              key1:
+#                - "value1"
+#          - name: "teacher"
+#            description: "this is a blah blah"
+#        default_roles:
+#          - "student"
+#          - "teacher"
+#        composite_roles:
+#          - name: "student"
+#            composites:
+#              - "offline_access"
+#              - "uma_authorization"
+#          - name: "teacher"
+#            composites:
+#              - "student"
 #      keys:
 #        - name: "rsa-sig"
 #          providerId: "rsa" #DO NOT CHANGE THIS

--- a/roles/keycloak/tasks/blocks/configure_basic_realm.yml
+++ b/roles/keycloak/tasks/blocks/configure_basic_realm.yml
@@ -1,0 +1,62 @@
+---
+
+- name: Acquire tokens
+  include_tasks: blocks/helpers/get_tokens.yml
+
+- name: "Check if realm {{ current_realm_item.name }} already exists"
+  uri:
+    url: "{{ keycloak_proxy_host }}/admin/realms/{{ current_realm_item.name }}"
+    method: GET
+    headers:
+      Authorization: "Bearer {{ tokens.json.access_token }}"
+    status_code: [200, 404]
+  register: "current_realm_search_result"
+
+- set_fact:
+    current_realm_exists: "{% if current_realm_search_result.status == 200 %}true{% else %}false{% endif %}"
+
+- name: "Initialize realm '{{ current_realm_item.name }}'"
+  uri:
+    url: "{{ keycloak_proxy_host }}/admin/realms"
+    method: POST
+    body_format: json
+    headers:
+      Authorization: "Bearer {{ tokens.json.access_token }}"
+    body:
+      enabled: true
+      id: "{{ current_realm_item.name }}"
+      realm: "{{ current_realm_item.name }}"
+    status_code: 201
+  when: current_realm_exists == false
+
+
+- name: "Get realm {{ current_realm_item.name }} config"
+  uri:
+    url: "{{ keycloak_proxy_host }}/admin/realms/{{ current_realm_item.name }}"
+    method: GET
+    headers:
+      Authorization: "Bearer {{ tokens.json.access_token }}"
+    status_code: 200
+  register: "current_realm_search_result"
+
+
+#at this point, we have a realm, either a created or an existing, loaded into the current_realm_search_result variable
+
+- name: "Fuse realm '{{ current_realm_item.name }}' configurations (existing and ansible's)"
+  set_fact:
+    realm_config_to_set: "{{ current_realm_search_result.json | combine(current_realm_item.config | default({}) , recursive=True ) }}"
+
+#now HTTP PUT the information (either the fused or the ansible's original config) to the realm's REST API
+- name: "Update realm {{ current_realm_item.name }}"
+  uri:
+    url: "{{ keycloak_proxy_host }}/admin/realms/{{ current_realm_item.name }}"
+    method: "PUT"
+    body_format: json
+    headers:
+      Authorization: "Bearer {{ tokens.json.access_token }}"
+    body:
+      "{{ realm_config_to_set }}"
+    status_code: "204"
+
+
+

--- a/roles/keycloak/tasks/blocks/roles_configuration/configure.yml
+++ b/roles/keycloak/tasks/blocks/roles_configuration/configure.yml
@@ -1,0 +1,25 @@
+---
+
+- name: Setup roles
+  include_tasks: configure_roles.yml
+  with_subelements:
+    - "{{ keycloak_config.realms | default([]) }} "
+    - "role_management.roles"
+    - skip_missing: true
+  run_once: true
+
+- name: Setup default roles
+  include_tasks: configure_default_roles.yml
+  with_subelements:
+    - "{{ keycloak_config.realms | default([]) }} "
+    - "role_management.default_roles"
+    - skip_missing: true
+  run_once: true
+
+- name: Setup composite roles
+  include_tasks: configure_role_composites.yml
+  with_subelements:
+    - "{{ keycloak_config.realms | default([]) }} "
+    - "role_management.composite_roles"
+    - skip_missing: true
+  run_once: true

--- a/roles/keycloak/tasks/blocks/roles_configuration/configure_default_roles.yml
+++ b/roles/keycloak/tasks/blocks/roles_configuration/configure_default_roles.yml
@@ -1,0 +1,32 @@
+---
+
+- name: Acquire tokens
+  include_tasks: blocks/helpers/get_tokens.yml
+
+- name: "Find full payload of all roles in the default_roles list"
+  uri:
+    url: "{{ keycloak_proxy_host }}/admin/realms/{{ item[0].name }}/roles/{{ default_role_name }}"
+    method: "GET"
+    headers:
+      Authorization: "Bearer {{ tokens.json.access_token }}"
+    status_code: 200
+  loop_control:
+    loop_var: default_role_name
+  with_items: "{{ item[1] }}"
+  register: search_results
+
+- set_fact:
+    default_roles_list_complete: "{{ search_results | json_query(query) | default([]) }}"
+  vars:
+    query: 'results[].json'
+
+- name: "Add default-roles in realm {{ item[0].name }}"
+  uri:
+    url: "{{ keycloak_proxy_host }}/admin/realms/{{ item[0].name }}/roles/default-roles-{{ item[0].name }}/composites"
+    method: "POST"
+    body_format: json
+    headers:
+      Authorization: "Bearer {{ tokens.json.access_token }}"
+    body:
+      "{{ default_roles_list_complete }}"
+    status_code: 204

--- a/roles/keycloak/tasks/blocks/roles_configuration/configure_role_composites.yml
+++ b/roles/keycloak/tasks/blocks/roles_configuration/configure_role_composites.yml
@@ -1,0 +1,33 @@
+---
+
+- name: Acquire tokens
+  include_tasks: blocks/helpers/get_tokens.yml
+
+- name: "Find full payload of all roles in the composite list"
+  uri:
+    url: "{{ keycloak_proxy_host }}/admin/realms/{{ item[0].name }}/roles/{{ composite_name }}"
+    method: "GET"
+    headers:
+      Authorization: "Bearer {{ tokens.json.access_token }}"
+    status_code: 200
+  loop_control:
+    loop_var: composite_name
+  with_items: "{{ item[1].composites }}"
+  register: search_results
+
+- set_fact:
+    composite_list_complete: "{{ search_results | json_query(query) | default([]) }}"
+  vars:
+    query: 'results[].json'
+
+
+- name: "Add composites of role {{ item[1].name }} in realm {{ item[0].name }}"
+  uri:
+    url: "{{ keycloak_proxy_host }}/admin/realms/{{ item[0].name }}/roles/{{ item[1].name }}/composites"
+    method: "POST"
+    body_format: json
+    headers:
+      Authorization: "Bearer {{ tokens.json.access_token }}"
+    body:
+      "{{ composite_list_complete }}"
+    status_code: 204

--- a/roles/keycloak/tasks/blocks/roles_configuration/configure_roles.yml
+++ b/roles/keycloak/tasks/blocks/roles_configuration/configure_roles.yml
@@ -1,0 +1,27 @@
+---
+
+- name: Acquire tokens
+  include_tasks: blocks/helpers/get_tokens.yml
+
+- name: "Get the role {{ item[1].name }} from realm {{ item[0].name }}"
+  uri:
+    url: "{{ keycloak_proxy_host }}/admin/realms/{{ item[0].name }}/roles/{{ item[1].name }}"
+    method: "GET"
+    headers:
+      Authorization: "Bearer {{ tokens.json.access_token }}"
+    status_code: [200, 404]
+  register: realm_role_inquiry
+
+- set_fact:
+    current_role_exists: "{% if realm_role_inquiry.status == 200 %}true{% else %}false{% endif %}"
+
+- name: "{% if current_role_exists %}Update{% else %}Update{% endif %} the role {{ item[1].name }} in realm {{ item[0].name }}"
+  uri:
+    url: "{{ keycloak_proxy_host }}/admin/realms/{{ item[0].name }}/roles{% if current_role_exists %}/{{ item[1].name }}{% endif %}"
+    method: "{% if current_role_exists %}PUT{% else %}POST{% endif %}"
+    body_format: json
+    headers:
+      Authorization: "Bearer {{ tokens.json.access_token }}"
+    body:
+      "{{ item[1] }}"
+    status_code: "{% if current_role_exists %}204{% else %}201{% endif %}"

--- a/roles/keycloak/tasks/configure.yml
+++ b/roles/keycloak/tasks/configure.yml
@@ -29,20 +29,11 @@
 - name: Configure the keycloak (AUP, realm keys, etc)
   block:
 
-    - name: Ensure that realm already exists
-      community.general.keycloak_realm:
-        auth_client_id: admin-cli
-        auth_keycloak_url: "{{ keycloak_proxy_host }}"
-        auth_realm: master
-        display_name_html: "<div class=\"kc-logo-text\"><span>{{ item.displayNameHtml }}</span></div>"
-        auth_username: "{{ keycloak_admin.user }}"
-        auth_password: "{{ keycloak_admin.pass }}"
-        id: "{{ item.name }}"
-        realm: "{{ item.name }}"
-        verify_email: "{{ item.verifyEmail }}"
-        enabled: true
-        state: present
+    - name: Apply realm.config parameters
+      include_tasks: blocks/configure_basic_realm.yml
       with_items: "{{ keycloak_config.realms | default([]) }}"
+      loop_control:
+        loop_var: current_realm_item
       run_once: true
 
     - name: Configure keys
@@ -73,33 +64,6 @@
         status_code: 204
       with_items: "{{ keycloak_config.realms | default([]) }}"
       when: not item.aup is undefined
-      run_once: true
-
-    - name: Setup SMTP
-      community.general.keycloak_realm:
-        auth_client_id: admin-cli
-        auth_keycloak_url: "{{ keycloak_proxy_host }}"
-        auth_realm: master
-        auth_username: "{{ keycloak_admin.user }}"
-        auth_password: "{{ keycloak_admin.pass }}"
-        id: "{{ item.name }}"
-        realm: "{{ item.name }}"
-        smtpServer:
-          port: "{{ item.smtp.port }}"
-          ssl: "{{ item.smtp.enable_ssl }}"
-          starttls: "{{ item.smtp.enable_starttls }}"
-          host: "{{ item.smtp.host }}"
-          fromDisplayName: "{{ item.smtp.from_name }}"
-          from: "{{ item.smtp.from_email }}"
-          replyToDisplayName: "{{ item.smtp.reply_to_name }}"
-          replyTo: "{{ item.smtp.reply_to_email }}"
-          envelopeFrom: "{{ item.smtp.envelope_from }}"
-          auth: "{{ item.smtp.auth_enabled }}"
-          user: "{{ item.smtp.auth_username }}"
-          password: "{{ item.smtp.auth_password }}"
-        state: present
-      with_items: "{{ keycloak_config.realms | default([]) }}"
-      when: not item.smtp is undefined
       run_once: true
 
     - name: Setup federations

--- a/roles/keycloak/tasks/configure.yml
+++ b/roles/keycloak/tasks/configure.yml
@@ -66,6 +66,9 @@
       when: not item.aup is undefined
       run_once: true
 
+    - name: Setup roles
+      include_tasks: blocks/roles_configuration/configure.yml
+
     - name: Setup federations
       include_tasks: blocks/configure_federations.yml
       with_subelements:


### PR DESCRIPTION
By integrating this change, whenever we want to alter a new property of the realm we will just need 

- to alter/add only the equivalent parameter on the `rciam-deploy-inv` 
- rather than editing the placeholders in this role and then also adding the values in the `rciam-deploy-inv`

It also merges the basic realm config parameters into a single call.

Also, this PR enables managing realm's roles:
- can create/update realm roles
- can set default realm roles
- can configure composite roles for the realm 

