### PR TITLE
keycloak role: added a keycloak-logs-level for SAML protocol (default: INFO)

### DIFF
--- a/roles/keycloak/defaults/main.yml
+++ b/roles/keycloak/defaults/main.yml
@@ -41,7 +41,7 @@ keycloak_logs_folder: "/var/log/keycloak"
 
 keycloak_logs_max_days: 548  # that's ~18 months
 
-keycloak_logs_level:
+keycloak_log_level:
   saml: INFO
 
 ### plugins

--- a/roles/keycloak/defaults/main.yml
+++ b/roles/keycloak/defaults/main.yml
@@ -41,6 +41,9 @@ keycloak_logs_folder: "/var/log/keycloak"
 
 keycloak_logs_max_days: 548  # that's ~18 months
 
+keycloak_logs_level:
+  saml: INFO
+
 ### plugins
 ### wayf plugin works ONLY with "stage" branch of keycloak (need to have commit fe055820980dbcb79d5aae2b4dce78b840b912b0)
 #keycloak_plugins:

--- a/roles/keycloak/templates/16.1.0/standalone-ha.xml.j2
+++ b/roles/keycloak/templates/16.1.0/standalone-ha.xml.j2
@@ -88,10 +88,10 @@
                 <level name="WARN"/>
             </logger>
             <logger category="org.apache.xml.security.encryption.XMLCipher">
-                <level name="{{keycloak_logs_level.saml}}"/>
+                <level name="{{ keycloak_log_level.saml }}"/>
             </logger>
             <logger category="org.keycloak.saml.SAMLRequestParser">
-                <level name="{{keycloak_logs_level.saml}}"/>
+                <level name="{{ keycloak_log_level.saml }}"/>
              </logger>
             <root-logger>
                 <level name="INFO"/>

--- a/roles/keycloak/templates/16.1.0/standalone-ha.xml.j2
+++ b/roles/keycloak/templates/16.1.0/standalone-ha.xml.j2
@@ -87,6 +87,12 @@
             <logger category="sun.rmi">
                 <level name="WARN"/>
             </logger>
+            <logger category="org.apache.xml.security.encryption.XMLCipher">
+                <level name="{{keycloak_logs_level.saml}}"/>
+            </logger>
+            <logger category="org.keycloak.saml.SAMLRequestParser">
+                <level name="{{keycloak_logs_level.saml}}"/>
+             </logger>
             <root-logger>
                 <level name="INFO"/>
                 <handlers>


### PR DESCRIPTION
According to [this](https://jira.argo.grnet.gr/browse/RCIAM-922) ticket
