### PR TITLE
[keycloak role] 

### DIFF
--- a/roles/keycloak/tasks/java/Debian-10.yml
+++ b/roles/keycloak/tasks/java/Debian-10.yml
@@ -4,4 +4,6 @@
   apt:
     name: openjdk-11-jdk
     state: present
+    update_cache: yes
+    cache_valid_time: 86400
   become: yes


### PR DESCRIPTION
In case that the apt runs first time on the machine, it needs to update, because it might have a outdated list of packages.
This is idempotent.