### PR TITLE
[keycloak role] federation_mappers url was in form http://http://host…

### DIFF
--- a/roles/keycloak/tasks/blocks/configure_federation_mapper.yml
+++ b/roles/keycloak/tasks/blocks/configure_federation_mapper.yml
@@ -40,7 +40,7 @@
 # You should execute it only when you are sure that the federation(s) are fully populated
 - name: Apply mappers (propagate) to federation IdP(s)
   uri:
-    url: "https://{{ keycloak_proxy_host }}/auth/admin/realms/{{ item[0].name }}/identity-provider-federation/instances/{{ realm_federation_matches[0].internalId }}/mappers/{{ body.id }}/idp/add"
+    url: "{{ keycloak_proxy_host }}/auth/admin/realms/{{ item[0].name }}/identity-provider-federation/instances/{{ realm_federation_matches[0].internalId }}/mappers/{{ body.id }}/idp/add"
     method: POST
     headers:
       Authorization: "Bearer {{ tokens.json.access_token }}"


### PR DESCRIPTION
Forgot a "http://" prepend from previous commits which leads to a url like this:
http://http://hostname/auth/admin/....
which of course is not a valid one