### PR TITLE
[keycloak role] removed an extra access token request

### DIFF
--- a/roles/keycloak/tasks/configure.yml
+++ b/roles/keycloak/tasks/configure.yml
@@ -25,13 +25,6 @@
       timeout: 600
 
 
-- name: Acquire tokens
-  include_tasks: blocks/helpers/get_tokens.yml
-  tags:
-    - "keycloak:config:realm_configuration"
-    - "keycloak:config:wayf_plugin"
-
-
 # configure AUP, realm keys, etc
 - name: Configure the keycloak (AUP, realm keys, etc)
   block:


### PR DESCRIPTION
I believe that i've found the offending task which leads to the http-401 in various cases. 
I managed to replicate the faulty scenario on the `kc-stable` deployment. 
By removing this task, it seems that the (synchronization?) issues which lead to the failure dissapear. 
Moreover, the next blocks have their own token renewal, so they are not affected by this removal.
I made a couple of tests after the removal, and i didn't get any failures.