### PR TITLE
Proposed configuration for changing terms_and_conditions

### DIFF
--- a/roles/keycloak/tasks/blocks/authentication/configure_first_broker_login.yml
+++ b/roles/keycloak/tasks/blocks/authentication/configure_first_broker_login.yml
@@ -34,9 +34,10 @@
       body:
         alias: "review profile config"
         config:
-          update.profile.on.first.login: "{{ current_realm.authentication.updateProfileOnFirstLogin }}"
+          update.profile.on.first.login: "{{ current_realm.authentication.updateProfileOnFirstLogin | default('missing') }}"
+          terms_and_conditions: "{{ current_realm.authentication.termsAndConditions | default('false') }}"
       status_code: 204
     #when: review_profile_id
     when: authentication_config_id
 
-  when: current_realm.authentication.updateProfileOnFirstLogin is defined
+  when: current_realm.authentication.updateProfileOnFirstLogin is defined || current_realm.authentication.termsAndConditions is defined


### PR DESCRIPTION
From Keycloak version _22.0.10-1.4rc2_ _terms_and_conditions_ has been added to _review profile config_ execution flow.
With the following addition, we check if at least one config for _review profile config_ execution flow exists.
Default value are default Keycloak values.
In previous Keycloak version, _terms_and_conditions_ does not exist.

I propose to add the PR and run to all Keycloak version.
In previous from _22.0.10-1.4rc2_  versions, an unnecessary value will be added. No problem.
Otherwise, for newer from _22.0.10-1.4rc2_  versions - and without this addition - _terms_and_conditions_ will be removed. It will take the default value (false).