### PR TITLE
Add Missing only to default - add hideUsername configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ Network Trash Folder
 Temporary Items
 .apdisk
 # END OSX.gitignore
+
+# Intellij
+.idea/*

--- a/roles/keycloak/defaults/main.yml
+++ b/roles/keycloak/defaults/main.yml
@@ -179,25 +179,27 @@ keycloak_themes:
 #           #   - "DISABLED": Disables cookie usage completely for browser
 #           #     authentication.
 #           cookie: "ALTERNATIVE"
+#        # Configure 'first-broker-login' authentication flow
 #        # Controls whether users can review their profile attributes that
 #        # Keycloak retrieves from an identity provider after their first login.
 #        # Possible values:
 #        #   - "on": Users are presented with the profile page requesting
 #        #     additional information
-#        #   - "missing" (default): Users are presented with the profile page
+#        #   - "missing" : Users are presented with the profile page
 #        #     only if the identity provider does not provide mandatory
 #        #     information, such as email, first name, or last name. User can change all values.
-#        #   - "missing-only": Users are presented with the profile page
+#        #   - "missing-only"(default): Users are presented with the profile page
 #        #     only if the identity provider does not provide mandatory
 #        #     information, such as email, first name, or last name. User can change only empty values.
 #        #   - "off": Users are not presented with the profile page
 #        # See https://www.keycloak.org/docs/latest/server_admin/#default-first-login-flow-authenticators
-#        updateProfileOnFirstLogin: "missing"
+#        updateProfileOnFirstLogin: "missing-only"
 #        # Controls whether users will be required to accept terms and
 #        # conditions before their profile is recorded (initial sign up). You
 #        # need to enable 'Terms and Conditions' Required action for this to
 #        # take effect. Defaults to "false".
 #        termsAndConditions: "true"
+#        hideUsername: "true"
 #      client_registration_policies:
 #        create_update:
 #          - name: "Allowed Client Scopes"

--- a/roles/keycloak/defaults/main.yml
+++ b/roles/keycloak/defaults/main.yml
@@ -186,7 +186,10 @@ keycloak_themes:
 #        #     additional information
 #        #   - "missing" (default): Users are presented with the profile page
 #        #     only if the identity provider does not provide mandatory
-#        #     information, such as email, first name, or last name
+#        #     information, such as email, first name, or last name. User can change all values.
+#        #   - "missing-only": Users are presented with the profile page
+#        #     only if the identity provider does not provide mandatory
+#        #     information, such as email, first name, or last name. User can change only empty values.
 #        #   - "off": Users are not presented with the profile page
 #        # See https://www.keycloak.org/docs/latest/server_admin/#default-first-login-flow-authenticators
 #        updateProfileOnFirstLogin: "missing"

--- a/roles/keycloak/tasks/blocks/authentication/configure_first_broker_login.yml
+++ b/roles/keycloak/tasks/blocks/authentication/configure_first_broker_login.yml
@@ -34,8 +34,9 @@
       body:
         alias: "review profile config"
         config:
-          update.profile.on.first.login: "{{ current_realm.authentication.updateProfileOnFirstLogin | default('missing') }}"
+          update.profile.on.first.login: "{{ current_realm.authentication.updateProfileOnFirstLogin | default('missing-only') }}"
           terms_and_conditions: "{{ current_realm.authentication.termsAndConditions | default('false') }}"
+          hideUsername: "{{ current_realm.authentication.hideUsername | default('false') }}"
       status_code: 204
     when: authentication_config_id
 


### PR DESCRIPTION
Although I believe that we should put first-broker-login flow as we do with browser flow, this will mean changes in all rciam-deploy-inv