### PR TITLE
Add a delay to make sure the service is up and running

### DIFF
--- a/roles/keycloak/tasks/configure.yml
+++ b/roles/keycloak/tasks/configure.yml
@@ -16,12 +16,15 @@
       delay: 10
       timeout: 180
   #wait for service to respond
-  - name: Waiting for service to be up and running...
-    uri:
-      url: "http://{{ keycloak_local_address }}:8080/{{ keycloak_base_url_path }}"
-      status_code: "200"
-      timeout: 600
-
+- name: Waiting for service to be up and running...
+  ansible.builtin.uri:
+    url: "http://{{ keycloak_local_address }}:8080/{{ keycloak_base_url_path }}"
+    status_code: 200
+    timeout: 10  # Max time per HTTP request
+  register: keycloak_web_check
+  until: keycloak_web_check.status == 200
+  retries: 15
+  delay: 10
 # configure AUP, realm keys, etc
 - name: Configure the keycloak (AUP, realm keys, etc)
   block:


### PR DESCRIPTION
Tried to upgrade the kc-dev-upstream, but I got an error. 

`2026-05-05 16:08:51,570 ERROR [org.infinispan.notifications.cachemanagerlistener.CacheManagerNotifierImpl] (jgroups-194,snf-23465-58118(v=16.0.8)) ISPN000405: Caught exception while invoking a cache manager listener! [Error Occurred After Shutdown]: org.infinispan.commons.CacheListenerException: ISPN000280: Caught exception [org.infinispan.commons.IllegalLifecycleStateException] while invoking method [public void org.keycloak.jgroups.certificates.CertificateReloadManager.onViewChanged(org.infinispan.notifications.cachemanagerlistener.event.ViewChangedEvent)] on listener instance: org.keycloak.jgroups.certificates.CertificateReloadManager@25146f9f
        at org.infinispan.notifications.impl.AbstractListenerImpl$ListenerInvocationImpl.lambda$invoke$0(AbstractListenerImpl.java:437)
        at `
        
 With this change we let the task to fail, wait for 10secs and then try again. This seems to be enough to let the service start correctly
        
  