### PR TITLE
FedReg Node v22 Upgrade, Fixed broken ams-agent config

### DIFF
--- a/roles/federation-registry/tasks/configure-environment.yml
+++ b/roles/federation-registry/tasks/configure-environment.yml
@@ -1,27 +1,54 @@
----
+- name: Remove old NodeSource repository files
+  file:
+    path: "{{ item }}"
+    state: absent
+  loop:
+    - /etc/apt/sources.list.d/nodesource.list
+    - /etc/apt/sources.list.d/nodesource.list.save
+
 - name: Install dependencies
   apt:
     pkg:
       - curl
       - git
       - nginx
+      - ca-certificates
+      - gnupg
+      - build-essential
+    state: present
+    update_cache: yes
 
-- name: Add node repository
-  shell: curl -sL https://deb.nodesource.com/setup_14.x | sudo bash -
+- name: Add Node.js 22 repository
+  shell: curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
   args:
     warn: no
 
-- name: Install node and npm
+- name: Upgrade Node.js from NodeSource
   apt:
-    pkg:
-      - build-essential
-      - nodejs
-      - npm
+    name: nodejs
+    state: latest
+    update_cache: yes
 
 - name: Install pm2
   npm:
     name: pm2
     global: yes
+
+- name: Check Node.js version
+  command: node -v
+  register: node_version
+  changed_when: false
+
+- name: Check npm version
+  command: npm -v
+  register: npm_version
+  changed_when: false
+
+- name: Show Node.js and npm versions
+  debug:
+    msg:
+      - "Node: {{ node_version.stdout }}"
+      - "npm: {{ npm_version.stdout }}"
 
 - name: Ensure Federation Pm2 Group Exists
   group:

--- a/roles/federation-registry/tasks/deploy.yml
+++ b/roles/federation-registry/tasks/deploy.yml
@@ -202,9 +202,9 @@
 
 - name: Ensure Pm2 Startup Script exists
   command:
-    cmd: "env PATH=$PATH:/usr/bin /usr/local/lib/node_modules/pm2/bin/pm2 startup systemd -u {{federation_pm2_user.name}} --hp {{federation_pm2_user.home}}"
+    cmd: "env PATH=$PATH:/usr/bin /usr/bin/pm2 startup systemd -u {{federation_pm2_user.name}} --hp {{federation_pm2_user.home}}"
   ignore_errors: yes
-  become: yes
+  become: yes 
 
 - name: Verify push endpoint if not verified
   run_once: true

--- a/roles/federation-registry/templates/ams-env.j2
+++ b/roles/federation-registry/templates/ams-env.j2
@@ -8,3 +8,4 @@ EXPRESS_URL=http://localhost:5000
 {% if federation_registry_ams is defined %}
 EXPRESS_KEY={{ federation_registry_ams.agent_key }}
 {% endif %}
+ENV={{federation_registry_deployment_env}}


### PR DESCRIPTION
- Upgrade Node.js from 14 to 22.
- Remove legacy NodeSource repository configuration.
- Use bundled npm from NodeSource instead of the Debian npm package.
- Add repository prerequisites (ca-certificates, gnupg).
- Add Node.js/npm version verification after installation.
- Restore missing ENV variable in AMS agent configuration.