### PR TITLE
Fix first-time host bootstrap gaps for rciam-metrics role

### DIFF
--- a/roles/rciam-metrics/tasks/bootstrap.yml
+++ b/roles/rciam-metrics/tasks/bootstrap.yml
@@ -11,12 +11,25 @@
   user:
     name: "{{ metrics_user.name }}"
     groups: "{{ metrics_user.group }}"
-    comment: "{{ metrics_user.gecos }}" 
+    comment: "{{ metrics_user.gecos }}"
     shell: "{{ metrics_user.shell }}"
     home: "{{ metrics_user.path }}"
     system: yes
     create_home: yes
     skeleton: "/empty"
+  become: yes
+
+- name: Ensure metrics user home directory is traversable by nginx
+  # The user module creates the home directory as 0700 by default, which
+  # blocks www-data (nginx) from traversing into it to follow the
+  # frontend symlinks under {{ metrics_path }}/javascript/. Only adds the
+  # execute bit for "other" so nginx can traverse; doesn't grant read/list,
+  # and files further down the tree (e.g. config.*.py, mode 0400) keep
+  # their own stricter permissions regardless.
+  file:
+    path: "{{ metrics_user.path }}"
+    state: directory
+    mode: "o+x"
   become: yes
 
 - name: Upgrade pip3

--- a/roles/rciam-metrics/tasks/deploy-backend.yml
+++ b/roles/rciam-metrics/tasks/deploy-backend.yml
@@ -95,6 +95,40 @@
   tags:
     - rciam-metrics:deploy-backend:logging
 
+- name: Ensure react folder is owned by metrics user
+  # {{ metrics_react_folder_name }} (javascript/) is only ever created as
+  # an implicit intermediate parent by deploy-frontend's "Ensure release
+  # directory exists" task, which targets a deeper per-tenant path. The
+  # file module doesn't apply owner/group to intermediates it has to
+  # create along the way, only to the exact path given - so this
+  # directory was left root:root (become:yes runs as root). Fix it here,
+  # once, tenant-independent, before deploy-frontend ever runs.
+  file:
+    path: "{{ metrics_path }}/{{ metrics_react_folder_name }}"
+    state: directory
+    owner: "{{ metrics_user.name }}"
+    group: "{{ metrics_user.group }}"
+  become: true
+  tags:
+    - rciam-metrics:deploy-backend:symlink
+
+- name: Ensure symlink target directories exist
+  # On a host's first-ever deploy, deploy_backend runs before
+  # deploy_frontend (see the workflow's job needs:), so the frontend
+  # directory this symlink points at may not exist yet. Ensure it's
+  # there (as a placeholder if needed) so the link doesn't depend on
+  # deploy order; deploy_frontend will populate it afterwards either way.
+  file:
+    path: "{{ item.symlink.target }}"
+    state: directory
+    owner: "{{ metrics_user.name }}"
+    group: "{{ metrics_user.group }}"
+  loop: "{{ metrics_config | default([]) }}"
+  become: true
+  when: item.symlink is defined
+  tags:
+    - rciam-metrics:deploy-backend:symlink
+
 - name: Create Symbolic links
   file:
     src: "{{ item.symlink.target }}"

--- a/roles/rciam-metrics/tasks/deploy-frontend.yml
+++ b/roles/rciam-metrics/tasks/deploy-frontend.yml
@@ -3,6 +3,8 @@
   file:
     path: "{{ metrics_path }}/{{ metrics_react_folder_name }}/{{tenant_environment | replace('.','_')}}/metrics-{{metrics_release}}"
     state: directory
+    owner: "{{ metrics_user.name }}"
+    group: "{{ metrics_user.name }}"
   become: yes
 
 # This needs the metrics_release, only github actions can know or if you set it manually

--- a/roles/rciam-metrics/tasks/install-Debian.yml
+++ b/roles/rciam-metrics/tasks/install-Debian.yml
@@ -13,6 +13,8 @@
       - nginx
       - python3-virtualenv
       - libpq-dev
+      - python3-packaging
+      - python3-setuptools
     state: present
     install_recommends: no
     update_cache: yes

--- a/roles/rciam-metrics/tasks/main.yml
+++ b/roles/rciam-metrics/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 
 # Include OS-specific installation tasks
-- include_tasks: install-Debian.yml
+- import_tasks: install-Debian.yml
   when: ansible_os_family == 'Debian'
   tags:
     - rciam-metrics:install


### PR DESCRIPTION
Found while bootstrapping a brand-new production node from scratch:

- main.yml: install-Debian.yml was pulled in via include_tasks, whose
  tags don't propagate to the tasks inside it. This silently skipped
  the OS package install task (nginx, git, build-essential, etc.) even
  when --tags rciam-metrics:install was passed. Switch to import_tasks
  so tags apply correctly.
- install-Debian.yml: add python3-packaging and python3-setuptools so
  the pip/unarchive/file modules work against Python 3.13 targets.
- bootstrap.yml: the metrics user's home directory is created 0700,
  which blocks nginx (www-data) from traversing into it to follow the
  frontend symlinks. Grant it o+x.
- deploy-backend.yml / deploy-frontend.yml: javascript/ and the
  per-tenant frontend directories were only ever created as unowned
  intermediate parents (root:root) by tasks that targeted a deeper
  path without setting owner/group. Own them explicitly. Also ensure
  the symlink target directory exists before deploy-backend creates
  the symlink, since deploy_backend can run before deploy_frontend on
  a host's first deploy.